### PR TITLE
Fixed example not Working

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ const promRegister = require('prom-client').register
 ioMetrics(io);
 
 // expose metrics endpoint
-app.get('/metrics', (req, res) => {
+app.get('/metrics', async (req, res) => {
   res.set('Content-Type', promRegister.contentType)
-  res.end(promRegister.metrics())
+  res.end(await promRegister.metrics())
 })
 ```
 


### PR DESCRIPTION
The code was not working due to the `promRegister.metrics()` function now is returning a `promise` instead of a `string`.