### PR TITLE
faster payload size measurement for Buffer type

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,16 +3,15 @@
 let promClient, metrics;
 
 function byteLen(payload) {
-  // NOTE: this could be extended to all types that directly have a .byteLength property.
-  // See documentation for Buffer.byteLength() for more info.
-  if (payload instanceof Buffer) {
-    return Buffer.byteLength(payload);
-  }
-  if (typeof payload === 'string') {
-    return Buffer.byteLength(payload, 'utf-8');
-  }
-
   try {
+    // NOTE: this could be extended to all types that directly have a .byteLength property.
+    // See documentation for Buffer.byteLength() for more info.
+    if (payload instanceof Buffer) {
+      return Buffer.byteLength(payload);
+    }
+    if (typeof payload === 'string') {
+      return Buffer.byteLength(payload, 'utf-8');
+    }
     return Buffer.byteLength(JSON.stringify(payload), 'utf-8');
   } catch (e) {
     return 0;

--- a/index.js
+++ b/index.js
@@ -2,14 +2,21 @@
 
 let promClient, metrics;
 
-function strToBytes(str) {
+function byteLen(payload) {
+  // NOTE: this could be extended to all types that directly have a .byteLength property.
+  // See documentation for Buffer.byteLength() for more info.
+  if (payload instanceof Buffer) {
+    return Buffer.byteLength(payload);
+  }
+  if (typeof payload === 'string') {
+    return Buffer.byteLength(payload, 'utf-8');
+  }
+
   try {
-    str = (typeof str === 'string') ? str : JSON.stringify(str);
+    return Buffer.byteLength(JSON.stringify(payload), 'utf-8');
   } catch (e) {
     return 0;
   }
-
-  return Buffer.byteLength(str || '', 'utf8');
 }
 
 function beforeHook(obj, methods, hook) {
@@ -104,7 +111,7 @@ function collectMetrics(io) {
       // ignore internal events
       if (event === 'newListener') return;
 
-      bytesTransmitted.labels(event).inc(strToBytes(eventStr));
+      bytesTransmitted.labels(event).inc(byteLen(eventStr));
       eventsSentTotal.labels(event).inc();
     });
 
@@ -123,7 +130,7 @@ function collectMetrics(io) {
       args[cbPos] = function() {
         const eventStr = Array.prototype.slice.call(arguments)[0];
 
-        bytesReceived.labels(event).inc(strToBytes(eventStr));
+        bytesReceived.labels(event).inc(byteLen(eventStr));
         eventsReceivedTotal.labels(event).inc();
 
         return origCb.apply(this, arguments);

--- a/test.js
+++ b/test.js
@@ -8,27 +8,31 @@ const promCollector = require('rewire')('./');
 
 describe('socket.io metrics: internal functions', () => {
   // retrieve unexported functions
-  const strToBytes = promCollector.__get__('strToBytes');
+  const byteLen = promCollector.__get__('byteLen');
   const beforeHook = promCollector.__get__('beforeHook');
 
-  it('strToBytes works with UTF8 string', () => {
-    expect(strToBytes('Шамиль')).to.eq(12);
+  it('byteLen works with UTF8 string', () => {
+    expect(byteLen('Шамиль')).to.eq(12);
   });
 
-  it('strToBytes works with non-UTF8 string', () => {
-    expect(strToBytes('Shamil')).to.eq(6);
+  it('byteLen works with non-UTF8 string', () => {
+    expect(byteLen('Shamil')).to.eq(6);
   });
 
-  it('strToBytes works with object', () => {
-    expect(strToBytes({ mesage: 'Hello World!' })).to.eq(25);
+  it('byteLen works with object', () => {
+    expect(byteLen({ message: 'Hello World!' })).to.eq(26);
   });
 
-  it('strToBytes returns 0 on exception or undefined', () => {
+  it('byteLen works with Buffer', () => {
+    expect(byteLen(Buffer.from('hello world'))).to.eq(11);
+  });
+
+  it('byteLen returns 0 on exception or undefined', () => {
     const obj = {};
     obj.a = { b: obj };
 
-    expect(strToBytes(obj)).to.eq(0);
-    expect(strToBytes(undefined)).to.eq(0);
+    expect(byteLen(obj)).to.eq(0);
+    expect(byteLen(undefined)).to.eq(0);
   });
 
   it('beforeHook returns false if first arg is undefined', () => {


### PR DESCRIPTION
Skip JSON serialization for Buffer types and use Buffer.byteLength() directly, similar to string types.

We discovered that, under load, this library's `JSON.stringify` call consumed ~80% of our used memory and ~70% of our CPU usage. Since we are sending `Buffer` objects through to socket.io, we can skip the JSON serialization and fetch the byte length directly.