### PR TITLE
update peer dependencies to allow prom-client 15

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
     "sinon": "^18.0.0"
   },
   "peerDependencies": {
-    "prom-client": ">=10 <15"
+    "prom-client": ">=10 <16"
   }
 }


### PR DESCRIPTION
There don't seem to be any meaningful breaking changes in prom-client 15. I've been using this in production for a while with no issues.